### PR TITLE
use workers instead of go connection. add a simple signal handler.

### DIFF
--- a/server.go
+++ b/server.go
@@ -5,16 +5,12 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"log"
 	"net"
-	"os"
-	"os/signal"
 	"runtime"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"golang.org/x/crypto/ed25519"
@@ -287,27 +283,4 @@ func RunServer(conf Conf) {
 		conns <-conn
 	}
 
-}
-
-func handleSignals() {
-        signals := make(chan os.Signal, 1)
-        signal.Notify(signals, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGUSR1)
-
-	for {
-		select {
-		case signal, ok := <-signals:
-			if !ok { break }
-
-			switch(signal) {
-			case syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM:
-				os.Exit(2)
-			case syscall.SIGUSR1:
-				if len(storedContent.ciphertextWithNonce) > 0 {
-					fmt.Printf("%v: some data is stored\n", os.Args[0])
-				} else {
-					fmt.Printf("%v: no data stored yet\n", os.Args[0])
-				}
-			}
-		}
-	}
 }

--- a/signals.go
+++ b/signals.go
@@ -1,0 +1,33 @@
+// +build !windows 
+
+package main
+
+import(
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func handleSignals() {
+        signals := make(chan os.Signal, 1)
+        signal.Notify(signals, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGUSR1)
+
+	for {
+		select {
+		case signal, ok := <-signals:
+			if !ok { break }
+
+			switch(signal) {
+			case syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM:
+				os.Exit(2)
+			case syscall.SIGUSR1:
+				if len(storedContent.ciphertextWithNonce) > 0 {
+					fmt.Printf("%v: some data is stored\n", os.Args[0])
+				} else {
+					fmt.Printf("%v: no data stored yet\n", os.Args[0])
+				}
+			}
+		}
+	}
+}

--- a/signals_windows.go
+++ b/signals_windows.go
@@ -1,0 +1,25 @@
+// +build windows
+
+package main
+
+import(
+	"os"
+	"os/signal"
+)
+
+func handleSignals() {
+        signals := make(chan os.Signal, 1)
+        signal.Notify(signals, os.Interrupt, os.Kill)
+
+	for {
+		select {
+		case signal, ok := <-signals:
+			if !ok { break }
+
+			switch(signal) {
+			case os.Interrupt, os.Kill:
+				os.Exit(2)
+			}
+		}
+	}
+}


### PR DESCRIPTION


the original implementation allows unlimited amount connections because it simply started a new goroutine for each connection. goroutines are cheaper then real threads, however they are still expensive. an attacker could easily start a few thousand connections and max out the resources of the server. there is no real defence against denial of service, so it must be ensured at least the program itself doesn't crash nor exhaust limits like memory and connection limits.

this is fixed by starting 2 * number of available cpus workers and accepting 4 * number of available cpus connections at the same time, otherwise the send "conns <-conn" blocks until a worker picks up the next connection.

addionally i've added a simple signal handler that covers SIGINT, SIGTERM and SIGQUIT for exit and SIGUSR1 tells if there is anything saved on the tty that it was started from.

and for the record: windoze sucks.