### PR TITLE
Use correct error for client copy flush failure

### DIFF
--- a/client.go
+++ b/client.go
@@ -64,7 +64,7 @@ func (client *Client) copyOperation(h1 []byte) {
 	writer.Write(ts)
 	writer.Write(signature)
 	writer.Write(ciphertextWithNonce)
-	if writer.Flush() != nil {
+	if err = writer.Flush(); err != nil {
 		log.Fatal(err)
 	}
 	rbuf := make([]byte, 32)


### PR DESCRIPTION
This error was outputting `<nil>` while I was debugging #18. This fixes it by assigning the flush error result to the `err` variable.

See https://github.com/jedisct1/piknik/issues/18#issuecomment-360486053