### PR TITLE
Fix empty server nonce

### DIFF
--- a/server.go
+++ b/server.go
@@ -161,7 +161,7 @@ func handleClientConnection(conf Conf, conn net.Conn) {
 		return
 	}
 	r2 := make([]byte, 32)
-	if _, err := rand.Read(r); err != nil {
+	if _, err := rand.Read(r2); err != nil {
 		log.Fatal(err)
 	}
 	h1 := auth1(conf, cnx.clientVersion, h0, r2)


### PR DESCRIPTION
Deriving from the protocol description r2 is supposed to be a "random 256-bit server nonce." Instead of generating and writing it into r2 it's written into r which is then never used again. r2 remains an empty byte-array of length 32. I suppose this was a typo. This should fix it.