### PR TITLE
Resolves TIME_WAIT socket accumulation on server

### DIFF
--- a/server.go
+++ b/server.go
@@ -470,6 +470,9 @@ func acceptClient(conf Conf, conn net.Conn) {
 
 func maybeAcceptClient(conf Conf, conn net.Conn) {
 	conn.SetDeadline(time.Now().Add(conf.Timeout))
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		tcpConn.SetLinger(0)
+	}
 	remoteIP := conn.RemoteAddr().(*net.TCPAddr).IP
 	for {
 		count := atomic.LoadUint64(&clientsCount)


### PR DESCRIPTION
When the server closes connections after handling operations, the server-side sockets enter TCP TIME_WAIT state for ~60 seconds. Under moderate load, this leads to hundreds of lingering sockets accumulating on the listening port:                                                                                                                                                                     

```bash
$ netstat -an | grep 8057 | grep TIME_WAIT | wc -l
> 490
```

Setting `SO_LINGER = 0` on accepted connections in `maybeAcceptClient` causes the kernel to send a RST on close and skip the `TIME_WAIT` state. This should be safe as each connection handles exactly one operation, data is fully read/written before close.